### PR TITLE
Add initial CLI application and library functionality

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,4 @@
+[settings]
+profile=black
+line_length=79
+multi_line_output=3

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@ Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
 SPDX-License-Identifier: BSD-3-Clause
 
 # SBOM Check
-Python library and CLI application that check a provided SPDX SBOM for
-adherence to the official specification [SPDX 2.3 specification](https://spdx.github.io/spdx-spec/v2.3/)
-and for the presence of a configurable set of required field values.
+Python library and CLI application that checks a provided SPDX v2.3
+SBOM in JSON format for adherence to the official [specification](https://spdx.github.io/spdx-spec/v2.3/)
+and for the presence of a set of minimum-required values.
 
 ## Requirements
 * Python 3.10+
 * `pip`, `setuptools`
-* See `requirements.txt` for Python application dependencies.
+* See `requirements.txt` for Python dependencies.
 
 ## CLI Application
 
@@ -28,17 +28,25 @@ Install CLI application:
 ```
 
 ### Usage
-The CLI application takes a single positional argument, the path to the root
-of the SBOM directory in which the SPDX JSON files are located.
-
-Run the `--help` command for full listing of CLI arguments.
+The CLI application takes a single positional argument, the path to the
+root of the SBOM directory in which SPDX JSON files are located.
 ```
- $ sbom-check --help
+usage: sbom-check [-h] [--print-console] [--print-json] spdx_json_folder
+
+sbom-check.
+
+positional arguments:
+  spdx_json_folder  Path to directory containing SPDX json file(s).
+
+options:
+  -h, --help        show this help message and exit
+  --print-console   Output results to console.
+  --print-json      Output results to a JSON file.
 ```
 
 ### Output
-On completion, the application will output the status of the run along with a
-detailed exceptions report if any validation checks failed.
+On completion, the application will output the status of the run along with
+a detailed exceptions report if any validation checks failed.
 
 ## Contributions
 Please see [CONTRIBUTIONS.md](CONTRIBUTIONS.md) for details.

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -3,7 +3,139 @@
 
 """CLI application."""
 
+import argparse
+import csv
+import json
+import logging
+from pathlib import Path
+from typing import Any, Iterable
+
+from sbom_check import CheckResult, check_sbom
+
+logger = logging.getLogger(__name__)
+
+SPDX_EXTENSION = ".spdx.json"
+OUTPUT_FILENAME = "results.json"
+
 
 def main() -> None:
-    """CLI application entrypoint."""
-    print("CLI entrypoint...")
+    """
+    Accepts arguments for running the validator through the CLI.
+    """
+    parser = argparse.ArgumentParser(description="sbom-check.")
+    parser.add_argument(
+        "spdx_folder",
+        metavar="spdx_json_folder",
+        help="Path to directory containing SPDX json file(s).",
+    )
+    parser.add_argument(
+        "--print-console",
+        action="store_true",
+        help="Output results to console.",
+    )
+    parser.add_argument(
+        "--print-json",
+        action="store_true",
+        help="Output results to a JSON file.",
+    )
+    args = parser.parse_args()
+
+    results = run(args.spdx_folder)
+
+    if args.print_console:
+        _print_results(results)
+
+    if args.print_json:
+        _output_json(results)
+
+    _output_csv(results)
+
+
+def run(spdx_root: str) -> dict[str, CheckResult]:
+    """
+    Runs the validator using the cli provided arguments
+    """
+    results = {}
+    for file, filename_error in _get_filenames(spdx_root):
+        if filename_error:
+            results[file.name] = CheckResult([], [filename_error])
+            # skip further processing of non-SPDX file
+            continue
+        print(f"\nParsing {file}")
+        with open(file, encoding="utf8") as content:
+            json_string = content.read()
+        results[file.name] = check_sbom(json_string)
+    return results
+
+
+def _get_filenames(path: str) -> Iterable[tuple[Path, str]]:
+    directory = Path(path)
+    for file in directory.glob("*"):
+        if file.is_file() and file.name.lower().endswith(SPDX_EXTENSION):
+            logger.info("SPDX file %s read.", file)
+            yield file, ""
+        else:
+            error = (
+                f"File {file} not recognized. Please ensure your files "
+                f"are SPDX JSON format and end with '{SPDX_EXTENSION}'."
+            )
+            logger.warning(error)
+            yield file, error
+
+
+def _print_results(results: dict[str, CheckResult]) -> None:
+    for filename, check_result in results.items():
+        if not check_result.is_valid:
+            print(f"\n{filename} is compliant.\n")
+            continue
+
+        if errors := check_result.errors:
+            print(
+                f"\n{filename} is not compliant, as it could not be parsed.\n"
+                f"The following errors were found:\n"
+            )
+            for error in errors:
+                print(f"* {error}\n")
+            continue
+
+        print(
+            f"\n{filename} successfully parsed, but was not compliant with "
+            "validation standards.\n"
+            "The following validation issues were found:\n"
+        )
+        for message in check_result.validation_messages:
+            _print_validation_message(message)
+
+
+def _print_validation_message(message: dict[str, str]) -> None:
+    print(f'* Message: {message["message"]}')
+    print(f'\ttype: {message["element_type"]}')
+    print(
+        f'\tspdx_id: {message["spdx_id"] or None}, '
+        f'parent id:{message["parent_id"]}\n'
+    )
+
+
+def _output_json(results: dict[str, CheckResult]) -> None:
+    with open(OUTPUT_FILENAME, "w", encoding="utf-8") as file:
+        json.dump(obj=_flattened_results(results), fp=file, indent=4)
+
+
+def _flattened_results(results: dict[str, Any]) -> dict[str, Any]:
+    return {
+        filename: {
+            "errors": result.errors,
+            "validator_results": result.validation_messages,
+        }
+        for filename, result in results.items()
+    }
+
+
+def _output_csv(results: dict[str, CheckResult]) -> None:
+    for filename, check_results in results.items():
+        if not check_results.is_valid:
+            with open(
+                f"{filename}_exceptions.csv", "w", encoding="utf-8"
+            ) as file:
+                csvwriter = csv.writer(file)
+                csvwriter.writerows(check_results.csv_rows)

--- a/src/sbom_check/__init__.py
+++ b/src/sbom_check/__init__.py
@@ -5,4 +5,4 @@
 
 """Package namespace exports."""
 
-from sbom_check.checks import check_sbom
+from sbom_check.checks import CheckResult, check_sbom

--- a/src/sbom_check/checks.py
+++ b/src/sbom_check/checks.py
@@ -3,14 +3,336 @@
 
 """SBOM Check library."""
 
+import json
 import logging
+from dataclasses import dataclass
+from typing import Any
+
+from license_expression import LicenseExpression
+from spdx_tools.spdx.model.document import CreationInfo, Document
+from spdx_tools.spdx.model.file import File
+from spdx_tools.spdx.model.package import Package
+from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
+from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
+from spdx_tools.spdx.parser.error import SPDXParsingError
+from spdx_tools.spdx.parser.jsonlikedict.json_like_dict_parser import (
+    JsonLikeDictParser,
+)
+from spdx_tools.spdx.validation.document_validator import (
+    SpdxElementType,
+    ValidationContext,
+    ValidationMessage,
+    validate_full_spdx_document,
+)
 
 logger = logging.getLogger(__name__)
 
+COMPLETENESS_EXCEPTION = "\n*** completeness exception ***\n"
+SPDX_VERSIONS = ["SPDX-2.3"]
 
-def check_sbom(spdx_json: str) -> None:
+# CSV header fields
+SPDX_ID = "spdx_id"
+PARENT_ID = "parent_id"
+ELEMENT_TYPE = "element_type"
+MESSAGE = "message"
+
+CSV_HEADER = [SPDX_ID, PARENT_ID, ELEMENT_TYPE, MESSAGE]
+
+
+@dataclass(frozen=True, slots=True)
+class CheckResult:
+    """SBOM check results for an SPDX document."""
+
+    _validation_messages: list[ValidationMessage]
+    errors: list[str]
+
+    @property
+    def is_valid(self) -> bool:
+        """
+        Return true if any errors or validation issues were detected.
+        """
+        return any([self._validation_messages, self.errors])
+
+    @property
+    def validation_messages(self) -> list[dict[str, str]]:
+        """
+        Return a list of validation message dicts.
+        """
+        return [
+            _validation_message_to_dict(message)
+            for message in self._validation_messages
+        ]
+
+    @property
+    def csv_rows(self) -> list[list[str]]:
+        """Returns csv header and rows populated with SBOM check results."""
+        return [CSV_HEADER] + [
+            [
+                message[SPDX_ID],
+                message[PARENT_ID],
+                message[ELEMENT_TYPE],
+                message[MESSAGE].replace("\n", ""),
+            ]
+            for message in self.validation_messages
+        ]
+
+
+def _validation_message_to_dict(message: ValidationMessage) -> dict[str, str]:
     """
-    Checks provided SPDX JSON string for adherence to official specification
-    and for the presence of values configured to be required.
+    Returns dict representation of provided ValidationMessage's contents.
     """
-    logger.debug("Checking %s", spdx_json)
+    return {
+        SPDX_ID: message.context.spdx_id or "",
+        PARENT_ID: message.context.parent_id or "",
+        ELEMENT_TYPE: str(message.context.element_type),
+        MESSAGE: message.validation_message,
+    }
+
+
+def check_sbom(spdx_json: str) -> CheckResult:
+    """
+    Validates provided SPDX JSON string for adherence to official specification
+    and for completeness.
+    """
+    spdx_dict = json.loads(spdx_json)
+    try:
+        spdx_document = _parse_spdx(spdx_dict)
+    except SPDXParsingError as error:
+        logger.warning("Failed to parse the provided JSON.")
+        error_messages = error.get_messages()  # type: ignore[no-untyped-call]
+        return CheckResult([], error_messages)
+
+    logger.info("JSON parsed. Beginning validation.")
+
+    validation_messages = validate_full_spdx_document(spdx_document)
+    logger.info("Completed standard SDPX Validation.")
+
+    validation_messages += check_completeness(spdx_document)
+    logger.info("Completed configured completeness SDPX Validation.")
+
+    return CheckResult(validation_messages, [])
+
+
+def _parse_spdx(spdx_dict: dict[str, Any]) -> Document:
+    """Converts dictionary into SPDX Document for verification."""
+    return JsonLikeDictParser().parse(json_like_dict=spdx_dict)  # type: ignore
+
+
+def check_completeness(document: Document) -> list[ValidationMessage]:
+    """
+    Runs completeness check to catch issues that the standard SPDX validator
+    doesn't recognize.
+    """
+    messages = []
+
+    # check document's creation_info values
+    messages += _check_creation_info(document.creation_info)
+
+    # check that document includes at least one package
+    if has_packages_msg := _check_has_packages(document):
+        messages.append(has_packages_msg)
+        return messages
+
+    # check the document's primary package
+    if primary_package_msg := _check_primary_package(document):
+        messages.append(primary_package_msg)
+
+    # check the document's dependency packages
+    messages += _check_packages(document.packages)
+
+    # check that the document includes at least one file
+    if has_files_msg := _check_has_files(document):
+        messages.append(has_files_msg)
+        return messages
+
+    # check the document's files
+    messages += _check_files(document.files)
+
+    return messages
+
+
+def _check_creation_info(
+    creation_info: CreationInfo,
+) -> list[ValidationMessage]:
+    messages = []
+    # check that the SPDX version is what we are expecting
+    if creation_info.spdx_version not in SPDX_VERSIONS:
+        messages.append(
+            _create_custom_validation_message(
+                message="The Document uses an invalid version. Valid "
+                f"versions include: {SPDX_VERSIONS}.",
+                element_type=SpdxElementType.CREATION_INFO,
+            )
+        )
+    # check the SPDX document has a name value
+    if not creation_info.name:
+        messages.append(
+            _create_custom_validation_message(
+                message="The Document has no name.",
+                element_type=SpdxElementType.CREATION_INFO,
+            )
+        )
+    # check that the SPDX document has a license list version
+    if not creation_info.license_list_version:
+        messages.append(
+            _create_custom_validation_message(
+                message="The Document does not have a license list version.",
+                element_type=SpdxElementType.CREATION_INFO,
+            )
+        )
+    return messages
+
+
+def _check_has_packages(document: Document) -> ValidationMessage | None:
+    # check that the document contains at least one package
+    if not document.packages:
+        return _create_custom_validation_message(
+            message="The Document contains no packages.",
+            element_type=SpdxElementType.DOCUMENT,
+        )
+    return None
+
+
+def _check_primary_package(document: Document) -> ValidationMessage | None:
+    primary_package_id = document.packages[0].spdx_id
+    document_id = document.creation_info.spdx_id
+    expected_describes_relationship = Relationship(
+        document_id, RelationshipType.DESCRIBES, primary_package_id
+    )
+    actual_describes_relationships = [
+        relationship
+        for relationship in document.relationships
+        if relationship.relationship_type == RelationshipType.DESCRIBES
+    ]
+
+    # check that there is only one describes relationship in the document
+    if len(actual_describes_relationships) != 1:
+        return _create_custom_validation_message(
+            message="This SPDX Document has an incorrect number of DESCRIBES "
+            "relationships. An SPDX document must directly describe one "
+            "top-level package. This document describes "
+            "f{len(actual_describes_relationships)} packages.",
+            element_type=SpdxElementType.DOCUMENT,
+        )
+
+    # check that the primary package is the first package entry
+    if expected_describes_relationship != actual_describes_relationships[0]:
+        return _create_custom_validation_message(
+            message="This SPDX Document's DESCRIBES relationship is to a "
+            "a package other than the first in the package info section. "
+            "Either the relationship is incorrect or the top-level package "
+            "that the document is describing is not first in the packages "
+            "collection.",
+            element_type=SpdxElementType.DOCUMENT,
+        )
+
+    return None
+
+
+def _check_packages(packages: list[Package]) -> list[ValidationMessage]:
+    messages = []
+    for package in packages:
+        # check that a supplier is provided for the package
+        if not package.supplier or isinstance(
+            package.supplier, SpdxNoAssertion
+        ):
+            messages.append(
+                _create_custom_validation_message(
+                    message="This package has no supplier populated.",
+                    element_type=SpdxElementType.PACKAGE,
+                    spdx_id=package.spdx_id,
+                )
+            )
+        # check that the package's files have been analyzed
+        if not package.files_analyzed:
+            messages.append(
+                _create_custom_validation_message(
+                    message="The files have not been analyzed for this "
+                    "package.",
+                    element_type=SpdxElementType.PACKAGE,
+                    spdx_id=package.spdx_id,
+                )
+            )
+        # check that at least one package license has been provided
+        if _has_licenses(package.license_concluded, package.license_declared):
+            if not package.copyright_text:
+                messages.append(
+                    _create_custom_validation_message(
+                        message="This package has declared licenses but no "
+                        "copyright text populated.",
+                        element_type=SpdxElementType.PACKAGE,
+                        spdx_id=package.spdx_id,
+                    )
+                )
+    return messages
+
+
+def _has_licenses(license_concluded: Any, license_declared: Any) -> bool:
+    return any(
+        [
+            isinstance(license_concluded, LicenseExpression),
+            isinstance(license_declared, LicenseExpression),
+        ]
+    )
+
+
+def _check_has_files(document: Document) -> ValidationMessage | None:
+    # check that the document contains at least one file
+    if not document.files:
+        return _create_custom_validation_message(
+            message="The Document contains no files.",
+            element_type=SpdxElementType.DOCUMENT,
+        )
+    return None
+
+
+def _check_files(files: list[File]) -> list[ValidationMessage]:
+    messages = []
+    for file in files:
+        # check if each file has a name
+        if not file.name:
+            messages.append(
+                _create_custom_validation_message(
+                    message="This file has no name.",
+                    element_type=SpdxElementType.FILE,
+                    spdx_id=file.spdx_id,
+                )
+            )
+
+        # remaining checks only relevant if file has concluded license
+        if not isinstance(file.license_concluded, LicenseExpression):
+            continue
+
+        # check if license_info_in_file is populated
+        if not file.license_info_in_file:
+            messages.append(
+                _create_custom_validation_message(
+                    message="This file has a concluded license but "
+                    "license_info_in_file is not populated.",
+                    element_type=SpdxElementType.FILE,
+                    spdx_id=file.spdx_id,
+                )
+            )
+
+        # check if file has copyright_text populated
+        if not file.copyright_text:
+            messages.append(
+                _create_custom_validation_message(
+                    message="This file has a concluded license but "
+                    "no copyright text.",
+                    element_type=SpdxElementType.FILE,
+                    spdx_id=file.spdx_id,
+                )
+            )
+
+    return messages
+
+
+def _create_custom_validation_message(
+    message: str,
+    element_type: SpdxElementType | None = None,
+    spdx_id: str = "",
+    element: Any = None,
+) -> ValidationMessage:
+    context = ValidationContext(spdx_id, None, element_type, element)
+    return ValidationMessage(COMPLETENESS_EXCEPTION + message, context)

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,8 +1,0 @@
-# Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
-# SPDX-License-Identifier: BSD-3-Clause
-
-from cli.main import main
-
-
-def test_main():
-    assert main() is None

--- a/tests/sbom_check/test_checks.py
+++ b/tests/sbom_check/test_checks.py
@@ -1,8 +1,0 @@
-# Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
-# SPDX-License-Identifier: BSD-3-Clause
-
-from sbom_check import check_sbom
-
-
-def test_check_sbom():
-    assert check_sbom("") is None

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import json
+
+import pytest
+
+from sbom_check import check_sbom
+
+
+@pytest.fixture
+def spdx_json_no_packages():
+    document = {
+        "spdxVersion": "SPDX-2.3",
+        "documentNamespace": "http://spdx.org/spdxdocs/la.vendor.13."
+        "2.0.r1-42c814b1-0331-4e6f-858d-37b9077e860a",
+        "creationInfo": {
+            "creators": [
+                "Organization: Qualcomm",
+                "Tool: qcom-sbom-tools-0.11.2.dev0+gf9e050f.d20230906",
+            ],
+            "created": "2023-09-07T20:33:12Z",
+            "licenseListVersion": "3.20",
+        },
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "Fake name",
+        "packages": [],
+    }
+    return json.dumps(document)
+
+
+@pytest.fixture
+def spdx_json1():
+    document = {
+        "spdxVersion": "SPDX-2.3",
+        "documentNamespace": "http://spdx.org/spdxdocs/la.vendor.13."
+        "2.0.r1-42c814b1-0331-4e6f-858d-37b9077e860a",
+        "creationInfo": {
+            "creators": [
+                "Organization: Qualcomm",
+                "Tool: qcom-sbom-tools-0.11.2.dev0+gf9e050f.d20230906",
+            ],
+            "created": "2023-09-07T20:33:12Z",
+        },
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "",
+        "packages": [
+            {
+                "SPDXID": "SPDXRef-LA.VENDOR.13.2.0.r1",
+                "name": "LA.VENDOR",
+                "downloadLocation": "NOASSERTION",
+                "filesAnalyzed": True,
+                "licenseConcluded": "NOASSERTION",
+                "licenseDeclared": "NOASSERTION",
+                "versionInfo": "13.2.0.r1",
+                "supplier": "Organization: Qualcomm",
+            }
+        ],
+    }
+    return json.dumps(document)
+
+
+@pytest.fixture
+def spdx_json2():
+    document = {
+        "spdxVersion": "SPDX-2.3",
+        "documentNamespace": "http://spdx.org/spdxdocs/la.vendor.13."
+        "2.0.r1-42c814b1-0331-4e6f-858d-37b9077e860a",
+        "creationInfo": {
+            "creators": [
+                "Organization: Qualcomm",
+                "Tool: qcom-sbom-tools-0.11.2.dev0+gf9e050f.d20230906",
+            ],
+            "created": "2023-09-07T20:33:12Z",
+            "licenseListVersion": "3.20",
+        },
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "Fake name",
+        "packages": [
+            {
+                "SPDXID": "SPDXRef-test.2",
+                "name": "LA.VENDOR",
+                "downloadLocation": "NOASSERTION",
+                "filesAnalyzed": False,
+                "licenseConcluded": "FAKE",
+                "licenseDeclared": "FAKE",
+                "versionInfo": "13.2.0.r1",
+                "supplier": "",
+            }
+        ],
+        "comment": "fake-comment",
+        "documentDescribes": ["SPDXRef-test.2"],
+        "files": [
+            {
+                "fileName": "fakepath",
+                "SPDXID": "SPDXRef-fakepath",
+                "checksums": [
+                    {"algorithm": "SHA1", "checksumValue": "NOASSERTION"}
+                ],
+                "licenseConcluded": "BSD-3-Clause",
+                "licenseInfoInFiles": ["BSD-3-Clause"],
+            }
+        ],
+    }
+    return json.dumps(document)
+
+
+@pytest.fixture
+def spdx_json3():
+    document = {
+        "spdxVersion": "SPDX-2.3",
+        "documentNamespace": "http://spdx.org/spdxdocs/la.vendor.13."
+        "2.0.r1-42c814b1-0331-4e6f-858d-37b9077e860a",
+        "creationInfo": {
+            "creators": [
+                "Organization: Qualcomm",
+                "Tool: qcom-sbom-tools-0.11.2.dev0+gf9e050f.d20230906",
+            ],
+            "created": "2023-09-07T20:33:12Z",
+            "licenseListVersion": "3.20",
+        },
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "Fake name",
+        "packages": [
+            {
+                "SPDXID": "SPDXRef-test.2",
+                "name": "LA.VENDOR",
+                "downloadLocation": "NOASSERTION",
+                "filesAnalyzed": True,
+                "licenseConcluded": "NOASSERTION",
+                "licenseDeclared": "NOASSERTION",
+                "versionInfo": "13.2.0.r1",
+                "supplier": "Organization: Qualcomm",
+            }
+        ],
+        "comment": "fake-comment",
+        "documentDescribes": ["SPDXRef-test.2"],
+        "files": [
+            {
+                "fileName": "fakepath",
+                "SPDXID": "SPDXRef-fakepath",
+                "checksums": [
+                    {"algorithm": "SHA1", "checksumValue": "NOASSERTION"}
+                ],
+                "licenseConcluded": "BSD-3-Clause",
+                "licenseInfoInFiles": [],
+            }
+        ],
+    }
+    return json.dumps(document)
+
+
+def test_check_empty_document():
+    result = check_sbom("{}")
+    assert result.errors == [
+        "Error while parsing document None: ['CreationInfo does not exist.']"
+    ]
+
+
+def test_check_creation_info(spdx_json1):
+    result = check_sbom(spdx_json1)
+
+    assert result.validation_messages[0]["message"] == (
+        "\n*** completeness exception ***\nThe Document has no name."
+    )
+    assert result.validation_messages[1]["message"] == (
+        "\n*** completeness exception ***\n"
+        "The Document does not have a license list version."
+    )
+
+
+def test_check_no_packages(spdx_json_no_packages):
+    result = check_sbom(spdx_json_no_packages)
+
+    assert result.validation_messages[0]["message"] == (
+        'there must be at least one relationship "SPDXRef-DOCUMENT DESCRIBES ..." '
+        'or "... DESCRIBED_BY SPDXRef-DOCUMENT" when there is not only a '
+        "single package present"
+    )
+    assert result.validation_messages[1]["message"] == (
+        "\n*** completeness exception ***\nThe Document contains no packages."
+    )
+
+
+def test_check_packages(spdx_json2):
+    result = check_sbom(spdx_json2)
+
+    assert result.validation_messages[3]["message"] == (
+        "\n*** completeness exception ***\n"
+        "This package has no supplier populated."
+    )
+    assert result.validation_messages[4]["message"] == (
+        "\n*** completeness exception ***\n"
+        "The files have not been analyzed for this package."
+    )
+    assert result.validation_messages[5]["message"] == (
+        "\n*** completeness exception ***\n"
+        "This package has declared licenses but no copyright text populated."
+    )
+
+
+def test_check_files(spdx_json3):
+    result = check_sbom(spdx_json3)
+
+    assert result.validation_messages[1]["message"] == (
+        "\n*** completeness exception ***\n"
+        "This file has a concluded license but license_info_in_file is not populated."
+    )
+    assert result.validation_messages[2]["message"] == (
+        "\n*** completeness exception ***\n"
+        "This file has a concluded license but no copyright text."
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
   black==24.4.2
 skip_install = true
 commands =
-  black --check --line-length 79 src setup.py
+  black --check --line-length 79 src tests setup.py
 
 [testenv:flake8]
 deps =
@@ -35,7 +35,7 @@ deps =
   -rrequirements.txt
   isort[pyproject]
 commands =
-  isort --check-only --diff src setup.py
+  isort --check-only --diff src tests setup.py
 
 [testenv:mypy]
 deps =
@@ -57,5 +57,5 @@ deps =
   {[testenv:isort]deps}
 skip_install = true
 commands =
-  black --line-length 79 src setup.py
-  isort --atomic src setup.py
+  black --line-length 79 src tests setup.py
+  isort --atomic src tests setup.py


### PR DESCRIPTION
# Description

Adds baseline functionality that validates SPDX version 2.3 (JSON format only) for adherence to the official specification and for the presence of a set of hard-coded minimum-required values (we intend to make these configurable in an upcoming PR).
