### PR TITLE
Fix stale SemanticValidator test left over from OWL-based implementation

### DIFF
--- a/tests/unit/spdx_validator/test_validators.py
+++ b/tests/unit/spdx_validator/test_validators.py
@@ -344,11 +344,9 @@ class TestJsonSchemaValidator:
 class TestSemanticValidator:
     """Test cases for SemanticValidator."""
 
-    def test_init_with_custom_ontology_path(self) -> None:
-        """Test validator initialization with custom ontology path (ignored)."""
-        custom_path = Path("/custom/ontology.owl")
-        validator = SemanticValidator(custom_path)
-        # The optimized validator doesn't use ontology files, but accepts the parameter
+    def test_init(self) -> None:
+        """Test validator initialization."""
+        validator = SemanticValidator()
         assert validator is not None
 
     def test_init_with_default_ontology_path(self) -> None:


### PR DESCRIPTION
# Description
`SemanticValidator.__init__` no longer accepts an argument — the OWL ontology path parameter was removed when the validator was rewritten to use direct constraint checking. The test `test_init_with_custom_ontology_path` was not updated at that time and would fail with a `TypeError` if run against the current implementation.

Renames the test to `test_init` and removes the spurious argument and stale commentary.

## Relevant issues/dependencies
None.

## Steps to Test or Reproduce
```
uv run pytest tests/unit/spdx_validator/test_validators.py::TestSemanticValidator::test_init -v
```

## Screenshots
N/A